### PR TITLE
Do not error when closing unhandled component

### DIFF
--- a/addon/services/stripe.js
+++ b/addon/services/stripe.js
@@ -49,7 +49,7 @@ export default Service.extend({
   open(component) {
     return this._stripeScriptPromise.then(() => {
       let config = this._stripeConfig(component);
-      let stripeHandler = this._stripeHandler(component);
+      let stripeHandler = this._stripeHandler(component) || this._registerNewStripeHandler(component);
       stripeHandler.open(config);
     });
   },
@@ -60,7 +60,10 @@ export default Service.extend({
    */
   close(component) {
     let stripeHandler = this._stripeHandler(component);
-    stripeHandler.close();
+
+    if (stripeHandler) {
+      stripeHandler.close();
+    }
   },
 
   init() {
@@ -98,6 +101,10 @@ export default Service.extend({
     if ('handler' in this._alive[componentGuid]) {
       return this._alive[componentGuid]['handler'];
     }
+  },
+
+  _registerNewStripeHandler(component) {
+    let componentGuid = guidFor(component);
 
     let stripeConfig = this._stripeConfig(component);
     if (!('key' in stripeConfig)) {

--- a/tests/unit/services/stripe-test.js
+++ b/tests/unit/services/stripe-test.js
@@ -62,7 +62,8 @@ test('unregisterComponent() unregisters the component', function(assert) {
 test('open() opens Stripe Checkout with correct config options', function(assert) {
   window.StripeCheckout = {
     configure() {},
-    open() {}
+    open() {},
+    close() {},
   };
   const openCheckoutSpy = this.spy();
   const configureCheckoutStub = this.stub(window.StripeCheckout, 'configure');
@@ -96,7 +97,8 @@ test('open() opens Stripe Checkout with correct config options', function(assert
 test('close() closes Stripe Checkout', function(assert) {
   window.StripeCheckout = {
     configure() {},
-    open() {}
+    open() {},
+    close() {},
   };
   const closeCheckoutSpy = this.spy();
   const configureCheckoutStub = this.stub(window.StripeCheckout, 'configure');
@@ -107,10 +109,18 @@ test('close() closes Stripe Checkout', function(assert) {
   const componentGuid = guidFor(stripeComponent);
   service._alive[componentGuid] = {
     component: stripeComponent,
+    handler: configureCheckoutStub(),
   };
-
 
   service.close(stripeComponent);
 
   assert.ok(closeCheckoutSpy.calledOnce, 'closes Stripe checkout when it is opened');
+});
+
+test('close() does nothing if StripeCheckout is not yet loaded', function(assert) {
+  const componentGuid = guidFor(stripeComponent);
+  service._alive[componentGuid] = {
+    component: stripeComponent,
+  };
+  assert.equal(null, service.close(stripeComponent), 'does not attempt to access StripeCheckout when it is not defined');
 });


### PR DESCRIPTION
Ensure that `close` can be called on the stripe service even if a
StripeCheckout handler had not yet been configured for that component.

Since the stripe handler is registered via `_stripeHandler`, a component that
is destroyed before the StripeCheckout JS is loaded would produce a
`StripeCheckout is undefined` error when invoking `_stripeHandler`.

One solution to this would have been to wrap the `close` function in the same
promise `open` uses to ensure StripeCheckout was available, but it seems to me
that `close` shouldn’t be responsible for registering a new handler simply to
delete it.

This also fixes previously broken tests.

I guess we can create a PR for this on the upstream repo after https://github.com/smile-io/ember-cli-stripe/pull/35 is merged.